### PR TITLE
Integrate Coffea executor with SkyhookDM backend

### DIFF
--- a/coffea/nanoaod/nanoevents.py
+++ b/coffea/nanoaod/nanoevents.py
@@ -297,35 +297,12 @@ class NanoEvents(awkward.Table):
         def isjagged(event):
             '''Detects whether the array is a JaggedArray or not.
             '''
-            name = event.split("_")[0]
-            jagged_events = [
-                'CorrT1METJet', 
-                'Electron', 
-                'GenJetAK8', 
-                'GenJet', 
-                'GenPart', 
-                'SubGenJetAK8', 
-                'GenVisTau', 
-                'IsoTrack', 
-                'Jet', 
-                'LHEPart', 
-                'Muon', 
-                'Photon', 
-                'GenDressedLepton', 
-                'SoftActivityJet', 
-                'Tau', 
-                'TrigObj', 
-                'SV'
-            ]
-
-            # is_jaggered = False
-            # try:
-            #     awkward1.to_numpy(arrays.events[event])
-            # except ValueError as ex:
-            #     is_jaggered = True
-            # return is_jaggered
-
-            return name in jagged_events
+            is_jaggered = False
+            try:
+                awkward1.to_numpy(arrays.events[event])
+            except ValueError as ex:
+                is_jaggered = True
+            return is_jaggered
 
         def generator(event):
             '''Generates numpy arrays out of Awkward Arrays.

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -820,7 +820,7 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                         from pyarrow import dataset as ds
                         import pyarrow as pa
 
-                        table = pa.ipc.open_stream('nano_dy_final.arrow'.format(item.filename[8:])).read_all()
+                        table = pa.ipc.open_stream('nano_dy.arrow'.format(item.filename[8:])).read_all()
                         das = ds.dataset(source=[item.filename[8:]], format=ds.RadosFormat("test-pool", "/etc/ceph/ceph.conf"), schema=table.schema)
                         table = das.to_table()
                         events = NanoEvents.from_arrow(

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -8,7 +8,6 @@ import sys
 import math
 import copy
 import shutil
-import awkward1 as ak
 import awkward
 import json
 import cloudpickle


### PR DESCRIPTION
Add a factory method `from_arrow` in the NanoEvents module to generate NanoEvents from Arrow IPC Tables.
Also, add support for reading RADOS objects from a SkyhookDM cluster from inside executors.
Tables in IPC format are read from SkyhookDM and are converted to NanoEvents to make them ready for further
processing from within executors.